### PR TITLE
Fixing incorrect git repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParsePlatform/open-api-server"
+    "url": "https://github.com/ParsePlatform/parse-server-example"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
* Fixes incorrect github link at https://www.npmjs.com/package/parse-server-example