### PR TITLE
Add kerberos as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "~4.2.x",
+    "kerberos": "~0.0.x",
     "parse": "~1.6.12",
     "parse-server": "~2.0.0"
   },


### PR DESCRIPTION
Prevents the following NPM warnings which will break in NPM 3

```
npm WARN peerDependencies The peer dependency kerberos@~0.0 included from mongodb-core will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```