### PR TITLE
Add Scalingo one click deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ Read the full server guide here: https://parse.com/docs/server/guide
 A detailed tutorial is available here:
 [Azure welcomes Parse developers](https://azure.microsoft.com/en-us/blog/azure-welcomes-parse-developers/)
 
+### Getting Started With Scalingo
+
+#### With the Scalingo button
+
+[![Deploy to Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy)
+
+#### Without it
+
+* Clone the repo and change directory to it
+* Log in with the [Scalingo CLI](http://cli.scalingo.com/) and create an app: `scalingo create my-parse`
+* Use the [Scalingo MongoDB addon](https://scalingo.com/addons/scalingo-mongodb): `scalingo addons-add scalingo-mongodb free`
+* Setup MongoDB connection string: `scalingo env-set DATABASE_URI='$SCALINGO_MONGO_URL'`
+* By default it will use a path of /parse for the API routes. To change this, or use older client SDKs, run `scalingo env-set PARSE_MOUNT=/1`
+* Deploy it with: `git push scalingo master`
+
 ### Using it
 
 You can use the REST API, the JavaScript SDK, and any of our open-source SDKs:

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,25 @@
+{
+  "name": "Parse Server Example",
+  "description": "An example Parse API server using the parse-server module",
+  "repository": "https://github.com/ParsePlatform/parse-server-example",
+  "logo": "https://avatars0.githubusercontent.com/u/1294580?v=3&s=200",
+  "env": {
+    "PARSE_MOUNT": {
+      "description": "Configure Parse API route.",
+      "value": "/parse"
+    },
+    "APP_ID": {
+      "description": "A unique identifier for your app.",
+      "value": ""
+    },
+    "MASTER_KEY": {
+      "description": "A key that overrides all permissions. Keep this secret.",
+      "value": ""
+    },
+    "DATABASE_URI": {
+      "description": "Connection string for your database.",
+      "value": "$SCALINGO_MONGO_URL"
+    }
+  },
+  "addons": ["scalingo-mongodb"]
+}


### PR DESCRIPTION
This PR adds the Scalingo deployment button and instructions to do the same manually, you can test it here: https://github.com/whollacsek/parse-server-example. 

Scalingo is a French PaaS compatible with Heroku.