### PR TITLE
Azure template and readme fixes

### DIFF
--- a/.ebextensions/app.config
+++ b/.ebextensions/app.config
@@ -1,9 +1,9 @@
 option_settings:
   aws:elasticbeanstalk:application:environment:
     PARSE_MOUNT: "/parse"
-    APP_ID: "MyAppID"
-    MASTER_KEY: "MySecretMasterKey"
-    DATABASE_URI: "mongodb://localhost:27017/dev"
+    APP_ID: "ReplaceWithAppID"
+    MASTER_KEY: "ReplaceWithMasterKey"
+    DATABASE_URI: "ReplaceWithDatabaseURI"
     NODE_ENV: "production"
 
   aws:elasticbeanstalk:container:nodejs:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,19 @@ Read the full server guide here: https://parse.com/docs/server/guide
 * By default it will use a path of /parse for the API routes.  To change this, or use older client SDKs, run `heroku config:set PARSE_MOUNT=/1`
 * Deploy it with: `git push heroku master`
 
-### Getting Started Microsoft Azure App Service
+### Getting Started With AWS Elastic Beanstalk
+
+#### With the Deploy to AWS Button
+
+[![Deploy to AWS](http://d0.awsstatic.com/product-marketing/Elastic%20Beanstalk/deploy-to-aws.png)](https://console.aws.amazon.com/elasticbeanstalk/home?region=us-west-2#/newApplication?applicationName=ParseServer&solutionStackName=Node.js&tierName=WebServer&sourceBundleUrl=https://s3.amazonaws.com/elasticbeanstalk-samples-us-east-1/eb-parse-server-sample/parse-server-example.zip)
+
+#### Without It
+
+* Clone the repo and change directory to it
+* Log in with the [AWS Elastic Beanstalk CLI](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-install.html), select a region, and create an app: `eb init`
+* Create an environment and pass in MongoDB URI, App ID, and Master Key: `eb create --envvars DATABASE_URI=<replace with URI>,APP_ID=<replace with Parse app ID>,MASTER_KEY=<replace with Parse master key>`
+
+### Getting Started With Microsoft Azure App Service
 
 #### With the Deploy to Azure Button
 
@@ -40,12 +52,6 @@ Read the full server guide here: https://parse.com/docs/server/guide
 
 A detailed tutorial is available here:
 [Azure welcomes Parse developers](https://azure.microsoft.com/en-us/blog/azure-welcomes-parse-developers/)
-
-### Getting Started With AWS Elastic Beanstalk
-
-* Clone the repo and change directory to it
-* Log in with the [AWS Elastic Beanstalk CLI](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-install.html), select a region, and create an app: `eb init`
-* Create an environment and pass in MongoDB URI, App ID, and Master Key: `eb create --envvars DATABASE_URI=<replace with URI>,APP_ID=<replace with Parse app ID>,MASTER_KEY=<replace with Parse master key>`
 
 ### Using it
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -102,11 +102,11 @@
                 "value": "[parameters('mongoConnectionString')]"
               },
             {
-            "name": "PARSE_APP_ID",
+            "name": "APP_ID",
             "value": "[parameters('parseAppId')]"
             },
             {
-            "name": "PARSE_MASTER_KEY",
+            "name": "MASTER_KEY",
             "value": "[parameters('parseMasterKey')]"
             },
             {


### PR DESCRIPTION
Small fix for the Azure deployment template so it uses the correct environment variable names (app settings) and minor correction to the readme section heading