### PR TITLE
Deploy with tutum (docker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,8 @@ ENV APP_ID setYourAppId
 ENV MASTER_KEY setYourMasterKey
 ENV DATABASE_URI setMongoDBURI
 
-# Optional (default : 'parse/cloud/main.js')
-# ENV CLOUD_CODE_MAIN cloudCodePath
-
-# Optional (default : '/parse')
-# ENV PARSE_MOUNT mountPath
+ENV CLOUD_CODE_MAIN /parse/cloud/main.js
+ENV PARSE_MOUNT /parse
 
 EXPOSE 1337
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Read the full server guide here: https://parse.com/docs/server/guide
 #### Deployment
 
 1. Register to [tutum.co](https://tutum.co)
-2. **Launch new node cluster** on your favorite provider (DigitalOcean, Azure, AWS, SoftLayer, Packet).
+2. **Launch new node cluster** on your favorite provider (DigitalOcean, Azure, AWS, SoftLayer, Packet)
 3. Click **Deploy to Tutum**, that's it
 
 [![Deploy to Tutum](https://s.tutum.co/deploy-to-tutum.svg)](https://dashboard.tutum.co/stack/deploy/)
 
 #### Configuration
 
-You can set your `APP_ID`, `MASTER_KEY`, `DATABASE_URI`, `CLOUD_CODE_MAIN` and `PARSE_MOUNT` just after you click **Deploy on Tutum**
+You can set your `APP_ID`, `MASTER_KEY`, `DATABASE_URI`, `CLOUD_CODE_MAIN` and `PARSE_MOUNT` just after you click **Deploy on Tutum**.
 
 ### Getting Started With Heroku + Mongolab Development
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ Read the full server guide here: https://parse.com/docs/server/guide
 * You now have a database named "dev" that contains your Parse data
 * Install ngrok and you can test with devices
 
+### Getting Started With Tutum (Docker)
+
+#### Deployment
+
+1. Register to [tutum.co](https://tutum.co)
+2. **Launch new node cluster** on your favorite provider (DigitalOcean, Azure, AWS, SoftLayer, Packet).
+3. Click **Deploy to Tutum**, that's it
+
+[![Deploy to Tutum](https://s.tutum.co/deploy-to-tutum.svg)](https://dashboard.tutum.co/stack/deploy/)
+
+#### Configuration
+
+You can set your `APP_ID`, `MASTER_KEY`, `DATABASE_URI`, `CLOUD_CODE_MAIN` and `PARSE_MOUNT` just after you click **Deploy on Tutum**
+
 ### Getting Started With Heroku + Mongolab Development
 
 #### With the Heroku Button

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "kerberos": "~0.0.x",
-    "parse-server": "~2.0"
+    "parse-server": "~2.0.7"
   },
   "scripts": {
     "start": "node index.js"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "express": "~4.2.x",
     "kerberos": "~0.0.x",
-    "parse": "~1.6.12",
     "parse-server": "~2.0"
   },
   "scripts": {

--- a/tutum.yml
+++ b/tutum.yml
@@ -1,5 +1,5 @@
 parse:
-  image: didierfranc/parse-server
+  image: didierfranc/parse-server-auto
   ports:
     - "1337:1337"
   tags:

--- a/tutum.yml
+++ b/tutum.yml
@@ -1,0 +1,21 @@
+parse:
+  image: didierfranc/parse-server
+  ports:
+    - "1337:1337"
+  tags:
+    - parse
+  environment:
+    - APP_ID=1111
+    - MASTER_KEY=1111
+    - ENV PARSE_MOUNT=/parse
+    - CLOUD_CODE_MAIN=/parse/cloud/main.js
+    - DATABASE_URI=mongodb://mongo:27017/parse
+  deployment_strategy: every_node
+ 
+mongo:
+  image: tutum/mongodb
+  tags:
+    - parse
+  environment:
+    - AUTH=no
+  deployment_strategy: every_node


### PR DESCRIPTION
I made this new pull with an automated build of **parse-server-example** as you can see it [here](https://hub.docker.com/r/didierfranc/parse-server-auto/). Indeed it's better than a manual build ...

**Dockerfile** is better with explicit environment variables
**Readme** has now a Tutum deployment button linked with his **tutum.yml**
**Package.json** express and parse dependencies are unnecessary there are in already in `"parse-server": "~2.0"`
