### PR TITLE
Remove default master key

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var api = new ParseServer({
   databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
   cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
   appId: process.env.APP_ID || 'myAppId',
-  masterKey: process.env.MASTER_KEY || 'myMasterKey'
+  masterKey: process.env.MASTER_KEY || '' //Add your master key here. Keep it secret!
 });
 // Client-keys like the javascript key or the .NET key are not necessary with parse-server
 // If you wish you require them, you can set them as options in the initialization above:


### PR DESCRIPTION
If there is a default master key, people will inevitably use it. And that would be bad.