### PR TITLE
Add a client key

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ var api = new ParseServer({
   databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
   cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
   appId: process.env.APP_ID || 'myAppId',
-  masterKey: process.env.MASTER_KEY || '' //Add your master key here. Keep it secret!
+  masterKey: process.env.MASTER_KEY || '', //Add your master key here. Keep it secret!
+  clientKey: process.env.CLIENT_KEY || 'clientKey',
 });
 // Client-keys like the javascript key or the .NET key are not necessary with parse-server
 // If you wish you require them, you can set them as options in the initialization above:


### PR DESCRIPTION
I'm somewhat confused by what the clientKey should be if it's considered optional based on
these instructions -- https://parse.com/docs/server/guide.

Should it not be included?  Or is there simply no ACL on Parse server and we should be using the master key always?

I noticed on the Android SDK that it requires it according to https://parse.com/docs/server/guide.  And it gets passed in as a header so seems to be required.  Are we basically considering BLANK to be OK?