### PR TITLE
Missing semicolon

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 var express = require('express');
 var ParseServer = require('parse-server').ParseServer;
 
-var databaseUri = process.env.DATABASE_URI || process.env.MONGOLAB_URI
+var databaseUri = process.env.DATABASE_URI || process.env.MONGOLAB_URI;
 
 if (!databaseUri) {
   console.log('DATABASE_URI not specified, falling back to localhost.');


### PR DESCRIPTION
Added a missing (but optional) semicolon at the end of `databaseUri` variable declaration for consistency.