### PR TITLE
passing serverURL argument to ParseServer

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,15 @@ if (!databaseUri) {
   console.log('DATABASE_URI not specified, falling back to localhost.');
 }
 
+var port = process.env.PORT || 1337;
+var mountPath = process.env.PARSE_MOUNT || '/parse';
+
 var api = new ParseServer({
   databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
   cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
   appId: process.env.APP_ID || 'myAppId',
-  masterKey: process.env.MASTER_KEY || '' //Add your master key here. Keep it secret!
+  masterKey: process.env.MASTER_KEY || '', //Add your master key here. Keep it secret!
+  serverURL: process.env.SERVER_URL || 'http://localhost:' + port + mountPath
 });
 // Client-keys like the javascript key or the .NET key are not necessary with parse-server
 // If you wish you require them, you can set them as options in the initialization above:
@@ -23,7 +27,6 @@ var api = new ParseServer({
 var app = express();
 
 // Serve the Parse API on the /parse URL prefix
-var mountPath = process.env.PARSE_MOUNT || '/parse';
 app.use(mountPath, api);
 
 // Parse Server plays nicely with the rest of your web routes
@@ -31,7 +34,6 @@ app.get('/', function(req, res) {
   res.status(200).send('I dream of being a web site.');
 });
 
-var port = process.env.PORT || 1337;
 app.listen(port, function() {
     console.log('parse-server-example running on port ' + port + '.');
 });


### PR DESCRIPTION
I'm finding that if I don't pass the serverURL argument into the newly created ParseServer, any queries that I run in cloud code fail with 401-unauthorized. I tracked this down to be because it was sending the query requests to api.parse.com.

Does this imply that the serverURL argument should be mandatory?