### PR TITLE
Bump parse-server version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "express": "~4.2.x",
     "kerberos": "~0.0.x",
     "parse": "~1.6.12",
-    "parse-server": "~2.1.2"
+    "parse-server": "~2.1.4"
   },
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
Parse Dashboard requires 2.1.4 or newer.