### PR TITLE
Fixed Typo

### DIFF
--- a/public/test.html
+++ b/public/test.html
@@ -14,7 +14,7 @@
 
       <div class="advice">
         <p><strong>Hi</strong>! We've prepared a small 3-steps page to assist you testing your local Parse server.</p>
-        <p>These first steps will help you run and test the Parse server locally and were referrenced by the <a href="https://github.com/ParsePlatform/parse-server/wiki/Migrating-an-Existing-Parse-App">migration guide</a> provided by <a href="https://github.com/ParsePlatform/">ParsePlataform</a>.</p>
+        <p>These first steps will help you run and test the Parse server locally and were referrenced by the <a href="https://github.com/ParsePlatform/parse-server/wiki/Migrating-an-Existing-Parse-App">migration guide</a> provided by <a href="https://github.com/ParsePlatform/">Parse Platform</a>.</p>
       </div>
 
       <p class="up-and-running">Looks like our local Parse Serve is running under <span id="parse-url">...</span>. Let’s test it? </p>


### PR DESCRIPTION
In the test html file here is a typo. It previously said "ParsePlataform", and I fixed it to say "Parse Platform"