### PR TITLE
fixes mongolab config var

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var express = require('express');
 var ParseServer = require('parse-server').ParseServer;
 var path = require('path');
 
-var databaseUri = process.env.DATABASE_URI || process.env.MONGOLAB_URI;
+var databaseUri = process.env.DATABASE_URI || process.env.MONGODB_URI;
 
 if (!databaseUri) {
   console.log('DATABASE_URI not specified, falling back to localhost.');
@@ -53,4 +53,3 @@ httpServer.listen(port, function() {
 
 // This will enable the Live Query real-time server
 ParseServer.createLiveQueryServer(httpServer);
-


### PR DESCRIPTION
Newly provisioned mLab addons are no longer attached to heroku applications as `MONGOLAB_URI`. Updated to `MONGODB_URI` to reflect this change.