### PR TITLE
Upgrade to parse server 2.2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "express": "~4.11.x",
     "kerberos": "~0.0.x",
     "parse": "~1.8.0",
-    "parse-server": "~2.2.2"
+    "parse-server": "~2.2.12"
   },
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
This upgrade fixes the time out issue with mongo db 2.1.19 and uses a parse server version with version 2.1.18 locked. 