### PR TITLE
Removed explicit Parse dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "express": "~4.11.x",
     "kerberos": "~0.0.x",
-    "parse": "~1.8.0",
     "parse-server": "*"
   },
   "scripts": {


### PR DESCRIPTION
As far as I know, this example code doesn't directly invoke the Parse Client SDK anywhere, so it doesn't need to list it as a dependency. The Parse package will still be included via the parse-server package.json.